### PR TITLE
Suggested changes to allow opening database from byte slice

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -29,7 +29,7 @@ type City struct {
 	Location struct {
 		Latitude  float64
 		Longitude float64
-		MetroCode int    `maxminddb:"metro_code"`
+		MetroCode string `maxminddb:"metro_code"`
 		TimeZone  string `maxminddb:"time_zone"`
 	}
 	Postal struct {


### PR DESCRIPTION
I want to run a geolocating service on Heroku, which doesn't have a durable filesystem, so I'd like to actually just fetch the maxmind database from the network at startup and read it into memory.  To this end, it's useful to be able to initialize maxminddb (and geoip2) from a byte slice.

I wasn't able to get gocheck to install because of a bzr/Python installation issue, so I can't actually verify that the test runs, but I'm guessing it will.
