### PR TITLE
Initialize location coordinates to NaN before lookup.

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -5,6 +5,7 @@
 package geoip2
 
 import (
+	"math"
 	"net"
 
 	"github.com/oschwald/maxminddb-golang"
@@ -133,6 +134,8 @@ func FromBytes(bytes []byte) (*Reader, error) {
 // method generally should be used with the GeoIP2 or GeoLite2 City databases.
 func (r *Reader) City(ipAddress net.IP) (*City, error) {
 	var city City
+	city.Location.Latitude = math.NaN()
+	city.Location.Longitude = math.NaN()
 	err := r.mmdbReader.Lookup(ipAddress, &city)
 	return &city, err
 }


### PR DESCRIPTION
It's useful to have a semantic concept of location coordinates not being available when using the result of a lookup. Currently, a lookup resulting in no location will return a coordinate set of `(0, 0)`. While this coordinate is in the Gulf of Guinea and thus could be argued to be a good "zero value" but `(NaN, NaN)` seems cleaner to me. Thoughts?

By the way, awesome work on the reader and lookup implementation!