### PR TITLE
Expose maxmindb metadata in geoip interface

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -111,6 +111,7 @@ type ISP struct {
 // using the Open function.
 type Reader struct {
 	mmdbReader *maxminddb.Reader
+	Metadata   *maxminddb.Metadata
 }
 
 // Open takes a string path to a file and returns a Reader structure or an
@@ -118,14 +119,22 @@ type Reader struct {
 // on the Reader object to return the resources to the system.
 func Open(file string) (*Reader, error) {
 	reader, err := maxminddb.Open(file)
-	return &Reader{mmdbReader: reader}, err
+	if err == nil {
+		return &Reader{mmdbReader: reader, Metadata: &reader.Metadata}, err
+	} else {
+		return &Reader{mmdbReader: reader}, err
+	}
 }
 
 // FromBytes takes a byte slice corresponding to a GeoIP2/GeoLite2 database
 // file and returns a Reader structure or an error.
 func FromBytes(bytes []byte) (*Reader, error) {
 	reader, err := maxminddb.FromBytes(bytes)
-	return &Reader{mmdbReader: reader}, err
+	if err == nil {
+		return &Reader{mmdbReader: reader, Metadata: &reader.Metadata}, err
+	} else {
+		return &Reader{mmdbReader: reader}, err
+	}
 }
 
 // City takes an IP address as a net.IP struct and returns a City struct

--- a/reader_test.go
+++ b/reader_test.go
@@ -2,11 +2,11 @@ package geoip2
 
 import (
 	"fmt"
+	. "launchpad.net/gocheck"
 	"math/rand"
 	"net"
 	"testing"
 	"time"
-	. "launchpad.net/gocheck"
 )
 
 func TestGeoIP2(t *testing.T) { TestingT(t) }
@@ -28,6 +28,19 @@ func (s *MySuite) TestReader(c *C) {
 		c.Log(err)
 		c.Fail()
 	}
+
+	c.Assert(reader.Metadata.BinaryFormatMajorVersion, Equals, uint(2))
+	c.Assert(reader.Metadata.BinaryFormatMinorVersion, Equals, uint(0))
+	c.Assert(reader.Metadata.BuildEpoch, Equals, uint(1403110838))
+	c.Assert(reader.Metadata.DatabaseType, Equals, "GeoIP2 City")
+	c.Assert(reader.Metadata.Description, DeepEquals, map[string]string{
+		"en": "GeoIP2 City Test Database (a small sample of real GeoIP2 data)",
+		"zh": "小型数据库",
+	})
+	c.Assert(reader.Metadata.IPVersion, Equals, uint(6))
+	c.Assert(reader.Metadata.Languages, DeepEquals, []string{"en", "zh"})
+	c.Assert(reader.Metadata.NodeCount, Equals, uint(1218))
+	c.Assert(reader.Metadata.RecordSize, Equals, uint(28))
 
 	c.Assert(record.City.GeoNameID, Equals, uint(2643743))
 	c.Assert(record.City.Names, DeepEquals, map[string]string{


### PR DESCRIPTION
I am not sure if this wants to be expressed in a different way, however some of the metadata (e.g. epoch build time) is useful for clients to retain to track db version numbers.

What do you think of exposing some (all ?) of the metadata in a given database ?