### PR TITLE
Add backwards compatibility for ASN to ISP (#46)

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -293,7 +293,7 @@ func getDBType(reader *maxminddb.Reader) (databaseType, error) {
 	case "GeoIP2-Enterprise":
 		return isEnterprise | isCity | isCountry, nil
 	case "GeoIP2-ISP", "GeoIP2-Precision-ISP":
-		return isISP, nil
+		return isISP | isASN, nil
 	default:
 		return 0, UnknownDatabaseTypeError{reader.Metadata.DatabaseType}
 	}


### PR DESCRIPTION
The same way GeoIP City can be used as a GeoIP Country, ASN has the same fields used in ISP.