### PR TITLE
Add DB() method to return underlying maxminddb 

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -415,3 +415,8 @@ func (r *Reader) Metadata() maxminddb.Metadata {
 func (r *Reader) Close() error {
 	return r.mmdbReader.Close()
 }
+
+// DB returns the underlying maxminddb reader.
+func (r *Reader) DB() *maxminddb.Reader {
+	return r.mmdbReader
+}


### PR DESCRIPTION
This ties in to my other patch at [1]; my goal is that geoIP entries are
inserted "on the fly" in the SQL database (which simplifies some
queries) when they're first seen; this removes the need to pre-populate
the database, makes sure the SQL database matches with the GeoIP
database, and future-proofs things better (new countries come in to
existence; for example the list I previously used didn't include
XK/Kosovo).

Right now there is no easy way to get at the maxminddb reader; I'd have
to create my own little struct which wraps the mmdbreader and scans in
the correct types. Not very difficult, but this is a bit easier.

[1]: oschwald/maxminddb-golang#75