### PR TITLE
Add IsResidentialProxy field to AnonymousIP

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -168,11 +168,12 @@ type Country struct {
 // The AnonymousIP struct corresponds to the data in the GeoIP2
 // Anonymous IP database.
 type AnonymousIP struct {
-	IsAnonymous       bool `maxminddb:"is_anonymous"`
-	IsAnonymousVPN    bool `maxminddb:"is_anonymous_vpn"`
-	IsHostingProvider bool `maxminddb:"is_hosting_provider"`
-	IsPublicProxy     bool `maxminddb:"is_public_proxy"`
-	IsTorExitNode     bool `maxminddb:"is_tor_exit_node"`
+	IsAnonymous        bool `maxminddb:"is_anonymous"`
+	IsAnonymousVPN     bool `maxminddb:"is_anonymous_vpn"`
+	IsHostingProvider  bool `maxminddb:"is_hosting_provider"`
+	IsPublicProxy      bool `maxminddb:"is_public_proxy"`
+	IsTorExitNode      bool `maxminddb:"is_tor_exit_node"`
+	IsResidentialProxy bool `maxminddb:"is_residential_proxy"`
 }
 
 // The ASN struct corresponds to the data in the GeoLite2 ASN database.

--- a/reader_test.go
+++ b/reader_test.go
@@ -143,6 +143,7 @@ func TestAnonymousIP(t *testing.T) {
 	assert.Equal(t, false, record.IsHostingProvider)
 	assert.Equal(t, false, record.IsPublicProxy)
 	assert.Equal(t, false, record.IsTorExitNode)
+	assert.Equal(t, false, record.IsResidentialProxy)
 }
 
 func TestASN(t *testing.T) {


### PR DESCRIPTION
Adds a new field `AnonymousIP.IsResidentialProxy` which is now supported by the Anonymous IP database per: https://dev.maxmind.com/geoip/geoip2/geoip2-anonymous-ip-csv-database/#Product_Information