### PR TITLE
[geoip2-golang]: expose maxminddb reader

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -413,6 +413,11 @@ func (r *Reader) Metadata() maxminddb.Metadata {
 	return r.mmdbReader.Metadata
 }
 
+// Reader allows to access to raw maxminddb Reader
+func (r *Reader) Reader() *maxminddb.Reader {
+	return r.mmdbReader
+}
+
 // Close unmaps the database file from virtual memory and returns the
 // resources to the system.
 func (r *Reader) Close() error {


### PR DESCRIPTION
sometimes it is usefull to have an access to raw maxminddb reader ( e.g. to use Networks feature; to iterate over db and build a reverse one ("show me all ips which belongs to XXx")). it feels like adding such feature to raw geoip library is to increase a complexity for not so common usecase; hence just exposing Reader on demand and allow for ppl who needs it to use it directly is cleaner method as for now