### PR TITLE
add Geoopen as dbtype 

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -132,7 +132,6 @@ func getDBType(reader *maxminddb.Reader) (databaseType, error) {
 	case "GeoIP2-Anonymous-IP":
 		return isAnonymousIP, nil
 	case "DBIP-ASN-Lite (compat=GeoLite2-ASN)",
-		"GeoOpen-Country-ASN",
 		"GeoLite2-ASN":
 		return isASN, nil
 	// We allow City lookups on Country for back compat


### PR DESCRIPTION
Luxembourg has open data available ([ODC-BY 1.0 license](https://opendatacommons.org/licenses/by/1-0/)):
https://data.public.lu/en/datasets/geo-open-ip-address-geolocation-per-country-in-mmdb-format/
Direct links:
https://cra.circl.lu/opendata/geo-open/mmdb-country-asn/latest.mmdb
https://cra.circl.lu/opendata/geo-open/mmdb-country/latest.mmdb

Can we add the db type ?