### PR TITLE
Add support for GeoIP Anonymous Plus database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changes
 
-## 2.0.2
+## 2.1.0 - 2025-12-22
 
+- Added support for the GeoIP Anonymous Plus database. This database provides
+  VPN detection with confidence scoring, provider identification, and temporal
+  tracking via the new `AnonymousPlus()` method.
 - Deprecated `IsLegitimateProxy` on `EnterpriseTraits`. MaxMind has deprecated
   this field and it will be removed in the next major release.
 - Deprecated `StaticIPScore` on `EnterpriseTraits`. This field was added in

--- a/README.md
+++ b/README.md
@@ -321,6 +321,64 @@ func main() {
 }
 ```
 
+### Anonymous Plus Database
+
+The Anonymous Plus database extends the Anonymous IP database with additional
+fields for confidence scoring, provider identification, and temporal tracking.
+
+```go
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/netip"
+
+	"github.com/oschwald/geoip2-golang/v2"
+)
+
+func main() {
+	db, err := geoip2.Open("GeoIP-Anonymous-Plus.mmdb")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	ip, err := netip.ParseAddr("1.2.0.1")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	record, err := db.AnonymousPlus(ip)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if !record.HasData() {
+		fmt.Println("No data found for this IP")
+		return
+	}
+
+	// Standard anonymous IP flags
+	fmt.Printf("Is Anonymous: %v\n", record.IsAnonymous)
+	fmt.Printf("Is Anonymous VPN: %v\n", record.IsAnonymousVPN)
+	fmt.Printf("Is Hosting Provider: %v\n", record.IsHostingProvider)
+	fmt.Printf("Is Public Proxy: %v\n", record.IsPublicProxy)
+	fmt.Printf("Is Residential Proxy: %v\n", record.IsResidentialProxy)
+	fmt.Printf("Is Tor Exit Node: %v\n", record.IsTorExitNode)
+
+	// Anonymous Plus specific fields
+	fmt.Printf("Anonymizer Confidence: %v\n", record.AnonymizerConfidence)
+	fmt.Printf("Provider Name: %v\n", record.ProviderName)
+	if !record.NetworkLastSeen.IsZero() {
+		fmt.Printf("Network Last Seen: %v\n", record.NetworkLastSeen.Format("2006-01-02"))
+	}
+
+	fmt.Printf("Network: %v\n", record.Network)
+	fmt.Printf("IP Address: %v\n", record.IPAddress)
+}
+```
+
 ### Enterprise Database
 
 The Enterprise database provides the most comprehensive data, including all

--- a/example_test.go
+++ b/example_test.go
@@ -162,6 +162,41 @@ func ExampleReader_AnonymousIP() {
 	// Is Public Proxy: false
 }
 
+// ExampleReader_AnonymousPlus demonstrates how to use the Anonymous Plus database.
+func ExampleReader_AnonymousPlus() {
+	db, err := Open("test-data/test-data/GeoIP-Anonymous-Plus-Test.mmdb")
+	if err != nil {
+		log.Panic(err)
+	}
+	defer db.Close()
+
+	ip, err := netip.ParseAddr("1.2.0.1")
+	if err != nil {
+		log.Panic(err)
+	}
+	record, err := db.AnonymousPlus(ip)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	if !record.HasData() {
+		fmt.Println("No data found for this IP")
+		return
+	}
+
+	fmt.Printf("Is Anonymous: %v\n", record.IsAnonymous)
+	fmt.Printf("Is Anonymous VPN: %v\n", record.IsAnonymousVPN)
+	fmt.Printf("Anonymizer Confidence: %v\n", record.AnonymizerConfidence)
+	fmt.Printf("Provider Name: %v\n", record.ProviderName)
+	fmt.Printf("Network Last Seen: %v\n", record.NetworkLastSeen.Format("2006-01-02"))
+	// Output:
+	// Is Anonymous: true
+	// Is Anonymous VPN: true
+	// Anonymizer Confidence: 30
+	// Provider Name: foo
+	// Network Last Seen: 2025-04-14
+}
+
 // ExampleReader_Enterprise demonstrates how to use the Enterprise database.
 func ExampleReader_Enterprise() {
 	db, err := Open("test-data/test-data/GeoIP2-Enterprise-Test.mmdb")

--- a/models.go
+++ b/models.go
@@ -1,6 +1,43 @@
 package geoip2
 
-import "net/netip"
+import (
+	"fmt"
+	"net/netip"
+	"time"
+
+	"github.com/oschwald/maxminddb-golang/v2/mmdbdata"
+)
+
+// Date represents a date value that is stored as an ISO 8601 string
+// in the database but exposed as a time.Time.
+type Date struct {
+	time.Time
+}
+
+// UnmarshalMaxMindDB implements the mmdbdata.Unmarshaler interface.
+func (d *Date) UnmarshalMaxMindDB(decoder *mmdbdata.Decoder) error {
+	s, err := decoder.ReadString()
+	if err != nil {
+		return err
+	}
+	if s == "" {
+		return nil
+	}
+	t, err := time.Parse(time.DateOnly, s)
+	if err != nil {
+		return fmt.Errorf("parsing date %q: %w", s, err)
+	}
+	d.Time = t
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler to serialize as ISO date string.
+func (d Date) MarshalJSON() ([]byte, error) { //nolint:unparam // error required by json.Marshaler
+	if d.IsZero() {
+		return []byte("null"), nil
+	}
+	return []byte(`"` + d.Format(time.DateOnly) + `"`), nil
+}
 
 // Names contains localized names for geographic entities.
 type Names struct {
@@ -516,6 +553,56 @@ type AnonymousIP struct {
 func (a AnonymousIP) HasData() bool {
 	return a.IsAnonymous || a.IsAnonymousVPN || a.IsHostingProvider ||
 		a.IsPublicProxy || a.IsResidentialProxy || a.IsTorExitNode
+}
+
+// The AnonymousPlus struct corresponds to the data in the GeoIP Anonymous Plus
+// database. This database provides VPN detection with confidence scoring,
+// provider identification, and temporal tracking.
+type AnonymousPlus struct {
+	// IPAddress is the IP address used during the lookup
+	IPAddress netip.Addr `json:"ip_address,omitzero"`
+	// Network is the largest network prefix where all fields besides
+	// IPAddress have the same value.
+	Network netip.Prefix `json:"network,omitzero"`
+	// NetworkLastSeen is the last day the network was sighted in anonymized
+	// network analysis.
+	NetworkLastSeen Date `json:"network_last_seen,omitzero"     maxminddb:"network_last_seen"`
+	// ProviderName is the name of the VPN provider (e.g., "NordVPN", "SurfShark").
+	ProviderName string `json:"provider_name,omitzero"         maxminddb:"provider_name"`
+	// AnonymizerConfidence is a score from 1 to 99 indicating the confidence
+	// that the network is part of an actively used VPN.
+	AnonymizerConfidence uint16 `json:"anonymizer_confidence,omitzero" maxminddb:"anonymizer_confidence"`
+	// IsAnonymous is true if the IP address belongs to any sort of anonymous network.
+	IsAnonymous bool `json:"is_anonymous,omitzero"          maxminddb:"is_anonymous"`
+	// IsAnonymousVPN is true if the IP address is registered to an anonymous
+	// VPN provider. If a VPN provider does not register subnets under names
+	// associated with them, we will likely only flag their IP ranges using the
+	// IsHostingProvider attribute.
+	IsAnonymousVPN bool `json:"is_anonymous_vpn,omitzero"      maxminddb:"is_anonymous_vpn"`
+	// IsHostingProvider is true if the IP address belongs to a hosting or VPN provider
+	// (see description of IsAnonymousVPN attribute).
+	IsHostingProvider bool `json:"is_hosting_provider,omitzero"   maxminddb:"is_hosting_provider"`
+	// IsPublicProxy is true if the IP address belongs to a public proxy.
+	IsPublicProxy bool `json:"is_public_proxy,omitzero"       maxminddb:"is_public_proxy"`
+	// IsResidentialProxy is true if the IP address is on a suspected
+	// anonymizing network and belongs to a residential ISP.
+	IsResidentialProxy bool `json:"is_residential_proxy,omitzero"  maxminddb:"is_residential_proxy"`
+	// IsTorExitNode is true if the IP address is a Tor exit node.
+	IsTorExitNode bool `json:"is_tor_exit_node,omitzero"      maxminddb:"is_tor_exit_node"`
+}
+
+// HasData returns true if any data was found for the IP in the AnonymousPlus database.
+// This excludes the Network and IPAddress fields which are always populated for found IPs.
+func (a AnonymousPlus) HasData() bool {
+	return a.AnonymizerConfidence != 0 ||
+		a.IsAnonymous ||
+		a.IsAnonymousVPN ||
+		a.IsHostingProvider ||
+		a.IsPublicProxy ||
+		a.IsResidentialProxy ||
+		a.IsTorExitNode ||
+		!a.NetworkLastSeen.IsZero() ||
+		a.ProviderName != ""
 }
 
 // The ASN struct corresponds to the data in the GeoLite2 ASN database.

--- a/reader_test.go
+++ b/reader_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/netip"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -163,6 +164,60 @@ func TestAnonymousIP(t *testing.T) {
 	assert.Equal(t, testAddr, record.IPAddress)
 	assert.True(t, record.Network.IsValid())
 	assert.True(t, record.Network.Contains(testAddr))
+}
+
+func TestAnonymousPlus(t *testing.T) {
+	reader, err := Open("test-data/test-data/GeoIP-Anonymous-Plus-Test.mmdb")
+	require.NoError(t, err)
+	defer reader.Close()
+
+	// Test IP with full data
+	testAddrFull := netip.MustParseAddr("1.2.0.1")
+	record, err := reader.AnonymousPlus(testAddrFull)
+	require.NoError(t, err)
+
+	assert.True(t, record.IsAnonymous)
+	assert.True(t, record.IsAnonymousVPN)
+	assert.False(t, record.IsHostingProvider)
+	assert.False(t, record.IsPublicProxy)
+	assert.False(t, record.IsTorExitNode)
+	assert.False(t, record.IsResidentialProxy)
+
+	// Anonymous Plus specific fields
+	assert.Equal(t, uint16(30), record.AnonymizerConfidence)
+	assert.Equal(t, "foo", record.ProviderName)
+	expectedDate := time.Date(2025, 4, 14, 0, 0, 0, 0, time.UTC)
+	assert.Equal(t, expectedDate, record.NetworkLastSeen.Time)
+
+	// Test Network and IPAddress fields
+	assert.Equal(t, testAddrFull, record.IPAddress)
+	assert.True(t, record.Network.IsValid())
+	assert.True(t, record.Network.Contains(testAddrFull))
+
+	// Test HasData
+	assert.True(t, record.HasData())
+
+	// Test IP with minimal data
+	testAddrMinimal := netip.MustParseAddr("1.2.0.0")
+	minRecord, err := reader.AnonymousPlus(testAddrMinimal)
+	require.NoError(t, err)
+
+	assert.True(t, minRecord.IsAnonymous)
+	assert.True(t, minRecord.IsAnonymousVPN)
+	assert.Equal(t, uint16(0), minRecord.AnonymizerConfidence)
+	assert.Empty(t, minRecord.ProviderName)
+	assert.True(t, minRecord.NetworkLastSeen.IsZero())
+	assert.True(t, minRecord.HasData())
+
+	// Test private IP returns empty data
+	privateAddr := netip.MustParseAddr("192.168.1.1")
+	emptyRecord, err := reader.AnonymousPlus(privateAddr)
+	require.NoError(t, err)
+
+	assert.False(t, emptyRecord.HasData())
+	// Network and IPAddress should still be set
+	assert.Equal(t, privateAddr, emptyRecord.IPAddress)
+	assert.True(t, emptyRecord.Network.IsValid())
 }
 
 func TestASN(t *testing.T) {
@@ -429,6 +484,7 @@ func TestAllStructsHaveHasData(t *testing.T) {
 	var country Country
 	var enterprise Enterprise
 	var anonymousIP AnonymousIP
+	var anonymousPlus AnonymousPlus
 	var asn ASN
 	var connectionType ConnectionType
 	var domain Domain
@@ -440,6 +496,7 @@ func TestAllStructsHaveHasData(t *testing.T) {
 	assert.False(t, country.HasData())
 	assert.False(t, enterprise.HasData())
 	assert.False(t, anonymousIP.HasData())
+	assert.False(t, anonymousPlus.HasData())
 	assert.False(t, asn.HasData())
 	assert.False(t, connectionType.HasData())
 	assert.False(t, domain.HasData())


### PR DESCRIPTION
This adds the AnonymousPlus() method for querying the GeoIP Anonymous Plus
database, which provides VPN detection with confidence scoring, provider
identification, and temporal tracking.

New features:
- AnonymousPlus struct with all standard anonymous IP flags plus:
  - AnonymizerConfidence (uint16): confidence score 1-99
  - ProviderName (string): VPN provider name
  - NetworkLastSeen (Date): last sighting date
- Date type that parses ISO date strings from MMDB and serializes to JSON
  as ISO date format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the GeoIP Anonymous Plus database: VPN detection with confidence scores, provider identification, and network last-seen tracking.

* **Documentation**
  * Added Anonymous Plus usage section to the README (note: duplicated content was added).

* **Bug Fixes / Deprecation**
  * Clarified that StaticIPScore was added in error and will be removed in the next major release; IsLegitimateProxy deprecation unchanged.

* **Tests / Examples**
  * Added example and tests demonstrating Anonymous Plus behavior and data presence checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->